### PR TITLE
Updated installMaGe to use mage-post-proc instead of GAT, to remove Majorana dirs, to use cmake instead of configure, and to add some options

### DIFF
--- a/installMaGe.py
+++ b/installMaGe.py
@@ -124,26 +124,24 @@ except subprocess.CalledProcessError:
     
 # install MGDO
 os.chdir('MGDO')
-subprocess.run(f'./configure --prefix={install_path} --enable-streamers --enable-tam --enable-tabree'.split())
-subprocess.run(['make', f'-j{args.jobs}'])
-if args.jobs>1:
-    subprocess.run(['make', '-j1']) # make -j>1 doesn't always succeed
-subprocess.run(['make', 'install', '-j1'])
+subprocess.run(f'./configure --prefix={install_path} --enable-streamers --enable-tam --enable-tabree'.split(), check=True)
+subprocess.run(f'make svninfo static -j{args.jobs}'.split(), check=True)
+subprocess.run('make', check=True)
+subprocess.run('make install'.split(), check=True)
 os.chdir('..')
 
 # install MaGe
-subprocess.run(f'cmake -S MaGe/source -B MaGe/build -DCMAKE_INSTALL_PREFIX={install_path}'.split())
+subprocess.run(f'cmake -S MaGe/source -B MaGe/build -DCMAKE_INSTALL_PREFIX={install_path}'.split(), check=True)
 os.chdir('MaGe/build')
-subprocess.run(['make', f'-j{args.jobs}'])
-subprocess.run(['make', 'install', '-j1'])
+subprocess.run(f'make -j{args.jobs}'.split(), check=True)
+subprocess.run('make install'.split(), check=True)
 os.chdir('../..')
 
 # install mage-post-proc
 os.chdir('mage-post-proc')
-subprocess.run(['make', f'-j{args.jobs}'])
-if args.jobs>1:
-    subprocess.run(['make', '-j1']) # make -j>1 doesn't always succeed
-subprocess.run(['make', 'install', '-j1'])
+subprocess.run(f'make -j{args.jobs} gitrev siggen static'.split(), check=True)
+subprocess.run('make', check=True)
+subprocess.run('make install'.split(), check=True)
 os.chdir(original_pwd)
 
 print('Installation complete. If desired, add the following line to your login script.')

--- a/installMaGe.py
+++ b/installMaGe.py
@@ -57,6 +57,11 @@ os.makedirs(args.buildpath, exist_ok=True)
 os.chdir(args.buildpath)
 pwd = os.getcwd()
 
+# helper function to run command line commands. Print command, then run it, and raise errors on failure
+def cmd(command):
+    print(command)
+    subprocess.run(command.split(), check=True)
+
 # determine install_path 
 install_path = args.installpath if args.installpath else pwd
 if not os.path.isdir(install_path):
@@ -121,34 +126,34 @@ try:
     address = 'git@github.com:' if args.authentication=='ssh' else\
               'https://github.com/'
     if not os.path.exists('MGDO'):
-        subprocess.run(f'git clone -b {args.mgdobranch} {address}{args.mgdofork}/MGDO.git'.split(), check=True)
+        cmd(f'git clone -b {args.mgdobranch} {address}{args.mgdofork}/MGDO.git')
     if not os.path.exists('MaGe'):
-        subprocess.run(f'git clone -b {args.magebranch} {address}{args.magefork}/MaGe.git MaGe/source'.split(), check=True)
+        cmd(f'git clone -b {args.magebranch} {address}{args.magefork}/MaGe.git MaGe/source')
     if not os.path.exists('mage-post-proc'):
-        subprocess.run(f'git clone -b {args.mppbranch} {address}{args.mppfork}/mage-post-proc.git'.split(), check=True)
+        cmd(f'git clone -b {args.mppbranch} {address}{args.mppfork}/mage-post-proc.git')
 except subprocess.CalledProcessError:
     sys.exit()
     
 # install MGDO
 os.chdir('MGDO')
-subprocess.run(f'./configure --prefix={install_path} --enable-streamers --enable-tam --enable-tabree'.split(), check=True)
-subprocess.run(f'make svninfo static -j{args.jobs}'.split(), check=True)
-subprocess.run('make', check=True)
-subprocess.run('make install'.split(), check=True)
+cmd(f'./configure --prefix={install_path} --enable-streamers --enable-tam --enable-tabree')
+cmd(f'make svninfo static -j{args.jobs}')
+cmd('make')
+cmd('make install')
 os.chdir('..')
 
 # install MaGe
-subprocess.run(f'cmake -S MaGe/source -B MaGe/build -DCMAKE_INSTALL_PREFIX={install_path}'.split(), check=True)
+cmd(f'cmake -S MaGe/source -B MaGe/build -DCMAKE_INSTALL_PREFIX={install_path}')
 os.chdir('MaGe/build')
-subprocess.run(f'make -j{args.jobs}'.split(), check=True)
-subprocess.run('make install'.split(), check=True)
+cmd(f'make -j{args.jobs}')
+cmd('make install')
 os.chdir('../..')
 
 # install mage-post-proc
 os.chdir('mage-post-proc')
-subprocess.run(f'make -j{args.jobs} gitrev siggen static'.split(), check=True)
-subprocess.run('make', check=True)
-subprocess.run('make install'.split(), check=True)
+cmd(f'make -j{args.jobs} gitrev siggen static')
+cmd('make')
+cmd('make install')
 os.chdir(original_pwd)
 
 print('Installation complete. If desired, add the following line to your login script.')

--- a/installMaGe.py
+++ b/installMaGe.py
@@ -52,6 +52,17 @@ os.makedirs(args.buildpath, exist_ok=True)
 os.chdir(args.buildpath)
 pwd = os.getcwd()
 
+# determine install_path 
+install_path = args.installpath if args.installpath else pwd
+if not os.path.isdir(install_path):
+    print(install_path, 'is not an existing directory')
+    print(usage)
+    sys.exit()
+
+# make absolutely sure necessary variables are set for (un)installation
+os.environ['MGDODIR']=pwd+'/MGDO'
+os.environ['PATH']=install_path+'/bin:'+os.environ['PATH']
+
 # clean up if desired
 if args.command == 'clean' or args.command == 'reinstall':
     if os.path.exists('mage-post-proc/Makefile'):
@@ -59,8 +70,8 @@ if args.command == 'clean' or args.command == 'reinstall':
         subprocess.run(['make', 'uninstall'])
         os.chdir('..')
     if os.path.exists('MaGe/build/install_manifest.txt'):
-      #subprocess.run(['make', 'uninstall'])
-      subprocess.run('xargs rm < MaGe/build/install_manifest.txt'.split())
+        subprocess.run('xargs -L1 rm -vf'.split(), stdin=open('MaGe/build/install_manifest.txt'))
+        subprocess.run('rm -vf Mage/build/install_manifest.txt'.split())
     if os.path.exists('MGDO/Makefile'):
         os.chdir('MGDO')
         subprocess.run(['make', 'uninstall'])
@@ -68,13 +79,6 @@ if args.command == 'clean' or args.command == 'reinstall':
     subprocess.run(['rm', '-rf', 'MGDO', 'MaGe', 'mage-post-proc', 'setup_mage.sh'])
     if args.command == 'clean':
         sys.exit()
-
-# determine install_path 
-install_path = args.installpath if args.installpath else pwd
-if not os.path.isdir(install_path):
-    print(install_path, 'is not an existing directory')
-    print(usage)
-    sys.exit()
 
 # find CLHEP
 try:
@@ -105,10 +109,6 @@ with open('setup_mage.sh', 'w') as file:
                f'{install_path}/include/mage-post-proc:' \
                '${ROOT_INCLUDE_PATH}\n')
     file.write(f'export PYTHONPATH={install_path}/lib:$PYTHONPATH\n')
-
-# make absolutely sure necessary variables are set for installation
-os.environ['MGDODIR']=pwd+'/MGDO'
-os.environ['PATH']=install_path+'/bin:'+os.environ['PATH']
 
 # download (user will enter password)
 try:

--- a/installMaGe.py
+++ b/installMaGe.py
@@ -99,6 +99,7 @@ with open('setup_mage.sh', 'w') as file:
     file.write(f'export TAMDIR=$MGDODIR/tam\n')
     file.write(f'export MAGEDIR={pwd}/MaGe/build\n')
     file.write(f'export MGGENERATORDATA={pwd}/share/MaGe/generators\n')
+    file.write(f'export MGGERDAGEOMETRY={pwd}/share/MaGe/gerdageometry\n')
     file.write(f'export MPPDIR={pwd}/mage-post-proc\n')
     file.write(f'export PATH={install_path}/bin:$PATH\n')
     file.write(f'export LD_LIBRARY_PATH={install_path}/lib:$LD_LIBRARY_PATH\n')

--- a/installMaGe.py
+++ b/installMaGe.py
@@ -30,6 +30,11 @@ parser.add_argument('-b', '--buildpath', type=str, default='.',
                     help="Base path to build software in")
 parser.add_argument('-i', '--installpath', type=str,
                     help="Base path to install software in. By default use the build path.")
+parser.add_argument('-a', '--authentication', type=str,
+                    choices=['ssh', 'https'], default='ssh',
+                    help="""github authentication method. Options:
+                        ssh: ssh-rsa key
+                        https: personal access token""")
 parser.add_argument('-j', '--jobs', type=int, default=1,
                     help="Number of threads to run with Make")
 
@@ -113,12 +118,14 @@ with open('setup_mage.sh', 'w') as file:
 
 # download (user will enter password)
 try:
+    address = 'git@github.com:' if args.authentication=='ssh' else\
+              'https://github.com/'
     if not os.path.exists('MGDO'):
-        subprocess.run(f'git clone -b {args.mgdobranch} https://github.com/{args.mgdofork}/MGDO.git'.split(), check=True)
+        subprocess.run(f'git clone -b {args.mgdobranch} {address}{args.mgdofork}/MGDO.git'.split(), check=True)
     if not os.path.exists('MaGe'):
-        subprocess.run(f'git clone -b {args.magebranch} https://github.com/{args.magefork}/MaGe.git MaGe/source'.split(), check=True)
+        subprocess.run(f'git clone -b {args.magebranch} {address}{args.magefork}/MaGe.git MaGe/source'.split(), check=True)
     if not os.path.exists('mage-post-proc'):
-        subprocess.run(f'git clone -b {args.mppbranch} https://github.com/{args.mppfork}/mage-post-proc.git'.split(), check=True)
+        subprocess.run(f'git clone -b {args.mppbranch} {address}{args.mppfork}/mage-post-proc.git'.split(), check=True)
 except subprocess.CalledProcessError:
     sys.exit()
     

--- a/installMaGe.py
+++ b/installMaGe.py
@@ -1,4 +1,4 @@
-import sys, os, subprocess, re
+import sys, os, subprocess, re, argparse
 
 usage = '''
 Usage: 
@@ -6,17 +6,9 @@ Usage:
 python /path/to/installMaGe.py (/optional/installation/path or clean)
 
 This script can be run from anywhere. It downloads and compiles MGDO, MaGe, and
-GAT in the directory from which it is executed. It also runs make install on
-MGDO and MaGe, installing them to /root/.local, or an alternative installation
+mage-post-proc in the directory from which it is executed. It also runs make
+install, installing to the current directory, or an alternative installation
 location of your choice.
-
-Instructions:
-cd /path/to/directory/where/you/want/the/source/code/to/be
-mkdir /installation/path/if/it/doesn't/exist
-python /path/to/installMaGe.py (/optional/installation/path)
-source setup_mage.sh
-python /path/to/installMaGe.py (/optional/installation/path)
-[follow instructions]
 
 You will be prompted to enter your github credentials to download each package
 before they are compiled.
@@ -26,91 +18,128 @@ To remove the installation, from the same directory containing the source code, 
 python /path/to/installMaGe.py clean
 '''
 
-help_strings = ['h', '-h', '--h', 'help', '-help', '--help']
-# check for the right number of arguments
-if len(sys.argv) > 2 or (len(sys.argv) > 1 and sys.argv[1] in help_strings):
-    print(usage)
-    sys.exit()
+parser = argparse.ArgumentParser(description = usage)
+
+parser.add_argument('command', type=str,
+                    choices=['install', 'clean', 'reinstall'],
+                    help="What action to take. Options:\n"\
+                    "  install: install from scratch\n"\
+                    "  clean: uninstall and remove\n"\
+                    "  reinstall: clean and then install\n")
+parser.add_argument('-b', '--buildpath', type=str, default='.',
+                    help="Base path to build software in")
+parser.add_argument('-i', '--installpath', type=str,
+                    help="Base path to install software in. By default use the build path.")
+parser.add_argument('-j', '--jobs', type=int,
+                    help="Number of threads to run with Make")
+
+parser.add_argument('--mgdofork', type=str, default='mppmu',
+                    help="Github fork to install MGDO from")
+parser.add_argument('--mgdobranch', type=str, default='master',
+                    help="Git branch to install MGDO from")
+parser.add_argument('--magefork', type=str, default='mppmu',
+                    help="Github fork to install MaGe from")
+parser.add_argument('--magebranch', type=str, default='master',
+                    help="Git branch to install MaGe from")
+parser.add_argument('--mppfork', type=str, default='legend-exp',
+                    help="Github fork to install MPP from")
+parser.add_argument('--mppbranch', type=str, default='master',
+                    help="Git branch to install MPP from")
+args = parser.parse_args()
+
+original_pwd = os.getcwd()
+os.makedirs(args.buildpath, exist_ok=True)
+os.chdir(args.buildpath)
+pwd = os.getcwd()
 
 # clean up if desired
-if len(sys.argv) == 2 and sys.argv[1] == 'clean':
-    if os.path.exists('MaGe/GNUmakefile'):
-      os.chdir('MaGe')
-      subprocess.run(['make', 'uninstall'])
-      os.chdir('..')
+if args.command == 'clean' or args.command == 'reinstall':
+    if os.path.exists('mage-post-proc/Makefile'):
+        os.chdir('mage-post-proc')
+        subprocess.run(['make', 'uninstall'])
+        os.chdir('..')
+    if os.path.exists('MaGe/build/install_manifest.txt'):
+      #subprocess.run(['make', 'uninstall'])
+      subprocess.run('xargs rm < MaGe/build/install_manifest.txt'.split())
     if os.path.exists('MGDO/Makefile'):
         os.chdir('MGDO')
         subprocess.run(['make', 'uninstall'])
         os.chdir('..')
-    subprocess.run(['rm', '-rf', 'MGDO', 'MaGe', 'GAT', 'setup_mage.sh'])
-    sys.exit()
+    subprocess.run(['rm', '-rf', 'MGDO', 'MaGe', 'mage-post-proc', 'setup_mage.sh'])
+    if args.command == 'clean':
+        sys.exit()
 
 # determine install_path 
-install_path = '/root/.local'
-if len(sys.argv) == 2: install_path = sys.argv[1]
+install_path = args.installpath if args.installpath else pwd
 if not os.path.isdir(install_path):
     print(install_path, 'is not an existing directory')
     print(usage)
     sys.exit()
 
-# store pwd
-pwd = subprocess.run(['pwd'], capture_output=True, encoding="utf-8").stdout.rstrip()
-
-# determine geant4, generate setup_mage.sh, and source it
-if not 'G4INSTALL' in os.environ:
-    print('Generating setup_mage.sh ...')
-    g4path = re.sub('data/G4EMLOW.*', '', os.environ['G4LEDATA'])
-    gatlibs = '$GATDIR/BaseClasses:$GATDIR/MGTEventProcessing' \
-            + ':$GATDIR/MGOutputMCRunProcessing:$GATDIR/Analysis' \
-            + ':$GATDIR/MJDAnalysis:$GATDIR/DCProcs'
-    with open('setup_mage.sh', 'w') as file:
-        file.write('source ' + g4path + 'geant4make/geant4make.sh\n')
-        file.write('export MGDODIR=' + pwd + '/MGDO\n')
-        file.write('export TAMDIR=$MGDODIR/tam\n')
-        file.write('export MAGEDIR=' + pwd + '/MaGe\n')
-        file.write('export MGGENERATORDATA=' + pwd + '/MaGe/generators/data\n')
-        file.write('export GATDIR=' + pwd + '/GAT\n')
-        file.write('export PATH=' + install_path + '/bin:$GATDIR/Apps:$PATH\n')
-        file.write('export LD_LIBRARY_PATH=' + install_path + '/lib:' + gatlibs + ':$TAMDIR/lib:$LD_LIBRARY_PATH\n')
-        file.write('export ROOT_INCLUDE_PATH=${CLHEP_INCLUDE_DIR}:' \
-                   + install_path + '/include:$TAMDIR:$GATDIR/BaseClasses:' \
-                   + '$GATDIR/MGTEventProcessing:$GATDIR/MGOutputMCRunProcessing:$GATDIR/PFunc\n')
-
-    print('Please do:')
-    print('source setup_mage.sh')
-    print('python', ' '.join(sys.argv))
+# find CLHEP
+try:
+    clhep_include_dir = os.environ.get('CLHEP_BASE_DIR', None)
+    if clhep_include_dir is None:
+        clhep_include_dir = subprocess.run(['clhep-config','--prefix'], check=True, universal_newlines=True, stdout=subprocess.PIPE).stdout.split('"')[1]
+    clhep_include_dir = clhep_include_dir + '/include'
+except Exception:
+    print("Could not find CLHEP_BASE_PATH or clhep-config")
     sys.exit()
 
+# determine geant4, generate setup_mage.sh, and source it
+print('Generating setup_mage.sh ...')
+g4path = re.sub('data/G4EMLOW.*', '', os.environ['G4LEDATA'])
+with open('setup_mage.sh', 'w') as file:
+    file.write(f'source {g4path}geant4make/geant4make.sh\n')
+    file.write(f'export MGDODIR={pwd}/MGDO\n')
+    file.write(f'export TAMDIR=$MGDODIR/tam\n')
+    file.write(f'export MAGEDIR={pwd}/MaGe/build\n')
+    file.write(f'export MGGENERATORDATA={pwd}/share/MaGe/generators\n')
+    file.write(f'export MPPDIR={pwd}/mage-post-proc\n')
+    file.write(f'export PATH={install_path}/bin:$PATH\n')
+    file.write(f'export LD_LIBRARY_PATH={install_path}/lib:$LD_LIBRARY_PATH\n')
+    file.write(f'export ROOT_INCLUDE_PATH={clhep_include_dir}:' \
+               f'{install_path}/include/mgdo:' \
+               f'{install_path}/include/tam:$TAMDIR:' \
+               f'{install_path}/include/mage:' \
+               f'{install_path}/include/mage-post-proc:' \
+               '${ROOT_INCLUDE_PATH}\n')
+    file.write(f'export PYTHONPATH={install_path}/lib:$PYTHONPATH\n')
+
+# make absolutely sure necessary variables are set for installation
+os.environ['MGDODIR']=pwd+'/MGDO'
+os.environ['PATH']=install_path+'/bin:'+os.environ['PATH']
 
 # download (user will enter password)
 try:
     if not os.path.exists('MGDO'):
-        subprocess.run(['git', 'clone', 'https://github.com/mppmu/MGDO.git'], check=True)
+        subprocess.run(f'git clone -b {args.mgdobranch} https://github.com/{args.mgdofork}/MGDO.git'.split(), check=True)
     if not os.path.exists('MaGe'):
-        subprocess.run(['git', 'clone', 'https://github.com/mppmu/MaGe.git'], check=True)
-    if not os.path.exists('GAT'):
-        subprocess.run(['git', 'clone', 'https://github.com/mppmu/GAT.git'], check=True)
+        subprocess.run(f'git clone -b {args.magebranch} https://github.com/{args.magefork}/MaGe.git MaGe/source'.split(), check=True)
+    if not os.path.exists('mage-post-proc'):
+        subprocess.run(f'git clone -b {args.mppbranch} https://github.com/{args.mppfork}/mage-post-proc.git'.split(), check=True)
 except subprocess.CalledProcessError:
     sys.exit()
-
+    
 # install MGDO
 os.chdir('MGDO')
-subprocess.run(['./configure', '--prefix='+install_path, '--enable-majorana-all'])
+subprocess.run(f'./configure --prefix={install_path} --enable-streamers --enable-tam --enable-tabree'.split())
 subprocess.run(['make'])
 subprocess.run(['make', 'install'])
 os.chdir('..')
 
 # install MaGe
-os.chdir('MaGe')
-subprocess.run(['./configure', '--prefix='+install_path, '--disable-g4gdml'])
+subprocess.run(f'cmake -S MaGe/source -B MaGe/build -DCMAKE_INSTALL_PREFIX={install_path}'.split())
+os.chdir('MaGe/build')
+subprocess.run(['make'] + (['-j', str(args.jobs)] if args.jobs else []) )
+subprocess.run(['make', 'install'])
+os.chdir('../..')
+
+# install mage-post-proc
+os.chdir('mage-post-proc')
 subprocess.run(['make'])
 subprocess.run(['make', 'install'])
-os.chdir('..')
-
-# install GAT
-os.chdir('GAT')
-subprocess.run(['make'])
-os.chdir('..')
+os.chdir(original_pwd)
 
 print('Installation complete. If desired, add the following line to your login script.')
 print('source', pwd + '/setup_mage.sh')


### PR DESCRIPTION
- Use mage-post-proc instead of GAT and remove Majorana/MJDB dependencies:
  - Note, this will rely on CrystalGeometry changes to MGDO that are still in a pull request
- Use cmake for MaGe
  - Following Luigi's recent work on using cmake for MaGe, I have switched over to using that instead of configure
  - This will rely on accepting that pull request!
  - If this is not desirable, let me know and I'll revert it to use configure
- Additional options:
  - Use argparse to parse options
  - Added options to specify forks and branches to pull from
  - Added -j option for multi-threaded building of MaGe. I think this requires cmake to work!
  - Changed default install directory to be same as build directory rather than /root/.local due to avoid persmissions problems
- In order to test this with the not-yet-accepted changes, you can do:
`python3 ~/legend-swdev-scripts/installMaGe.py install --mgdofork iguinn --mgdobranch crystalsurface --magebranch cmake -j4`