### PR TITLE
Fixes to install in legend container

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installs MGDO, MaGe, and GAT for people with access to those repositories on [mp
 ```console
 $ mkdir [installdir]
 $ python installMaGe.py --help # for help
-$ python installMaGe.py install --magebranch cmake -i [installdir] -j8 # for example
+$ python installMaGe.py install -i [installdir] -j8 # for example
 $ echo "$PWD/setup_mage.sh" ~/.bashrc
 ```
 

--- a/installMaGe.py
+++ b/installMaGe.py
@@ -44,11 +44,11 @@ parser.add_argument('--mgdobranch', type=str, default='master',
                     help="Git branch to install MGDO from")
 parser.add_argument('--magefork', type=str, default='mppmu',
                     help="Github fork to install MaGe from")
-parser.add_argument('--magebranch', type=str, default='master',
+parser.add_argument('--magebranch', type=str, default='main',
                     help="Git branch to install MaGe from")
 parser.add_argument('--mppfork', type=str, default='legend-exp',
                     help="Github fork to install MPP from")
-parser.add_argument('--mppbranch', type=str, default='master',
+parser.add_argument('--mppbranch', type=str, default='main',
                     help="Git branch to install MPP from")
 args = parser.parse_args()
 

--- a/installMaGe.py
+++ b/installMaGe.py
@@ -60,7 +60,13 @@ pwd = os.getcwd()
 # helper function to run command line commands. Print command, then run it, and raise errors on failure
 def cmd(command):
     print(command)
-    subprocess.run(command.split(), check=True)
+    subprocess.run(command, shell=True, check=True)
+
+# Disable conda for configure/cmake steps if needed
+preconfigure = ''
+if os.path.exists(os.path.join(sys.prefix, 'conda-meta')):
+    print("Disabling conda for configure steps...")
+    preconfigure = 'source disable-conda.sh; '
 
 # determine install_path 
 install_path = args.installpath if args.installpath else pwd
@@ -136,14 +142,14 @@ except subprocess.CalledProcessError:
     
 # install MGDO
 os.chdir('MGDO')
-cmd(f'./configure --prefix={install_path} --enable-streamers --enable-tam --enable-tabree')
+cmd(f'{preconfigure}./configure --prefix={install_path} --enable-streamers --enable-tam --enable-tabree')
 cmd(f'make svninfo static -j{args.jobs}')
 cmd('make')
 cmd('make install')
 os.chdir('..')
 
 # install MaGe
-cmd(f'cmake -S MaGe/source -B MaGe/build -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX={install_path}')
+cmd(f'{preconfigure}cmake -S MaGe/source -B MaGe/build -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX={install_path}')
 os.chdir('MaGe/build')
 cmd(f'make -j{args.jobs}')
 cmd('make install')

--- a/installMaGe.py
+++ b/installMaGe.py
@@ -143,7 +143,7 @@ cmd('make install')
 os.chdir('..')
 
 # install MaGe
-cmd(f'cmake -S MaGe/source -B MaGe/build -DCMAKE_INSTALL_PREFIX={install_path}')
+cmd(f'cmake -S MaGe/source -B MaGe/build -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX={install_path}')
 os.chdir('MaGe/build')
 cmd(f'make -j{args.jobs}')
 cmd('make install')


### PR DESCRIPTION
- Use C++14 for MaGe. This is needed if ROOT is installed using C++14, which is the default for recent versions
- If conda is installed, disable it before configuring. Conda has it's own separate installations of some dependencies that interfere with the ones used by ROOT and Geant4 (both of which are installed against the ubuntu rather than the conda versions).