### PR TITLE
Added --pipinstall[global/user] options to install MPP to site-packages dirs

### DIFF
--- a/installMaGe.py
+++ b/installMaGe.py
@@ -130,7 +130,7 @@ with open('setup_mage.sh', 'w') as file:
                f'{install_path}/include/mage:' \
                f'{install_path}/include/mage-post-proc:' \
                '${ROOT_INCLUDE_PATH}\n')
-    file.write(f'export PYTHONPATH={install_path}/lib:$PYTHONPATH\n')
+    file.write(f'export PYTHONPATH={install_path}/lib/magepostproc:$PYTHONPATH\n')
 
 # download (user will enter password)
 try:

--- a/installMaGe.py
+++ b/installMaGe.py
@@ -149,7 +149,10 @@ cmd('make install')
 os.chdir('..')
 
 # install MaGe
-cmd(f'{preconfigure}cmake -S MaGe/source -B MaGe/build -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX={install_path}')
+root_cflags = subprocess.check_output("root-config --cflags".split()).decode("utf-8")
+cppstd = re.search("-std=c\+\+(\d*)", root_cflags)
+cppstd = f"-DCMAKE_CXX_STANDARD={cppstd.group(1)}" if cppstd else ""
+cmd(f'{preconfigure}cmake -S MaGe/source -B MaGe/build {cppstd} -DCMAKE_INSTALL_PREFIX={install_path}')
 os.chdir('MaGe/build')
 cmd(f'make -j{args.jobs}')
 cmd('make install')


### PR DESCRIPTION
This will enable users to import magepostproc without any additional environment setup (like setting LD_LIBRARY_PATH or sourcing the setup script), which will ease use in the container. Note that when using MaGe, user will still have to set up environment. This depends on this pull request to work https://github.com/mppmu/MGDO/pull/300